### PR TITLE
fix serviceaccount name

### DIFF
--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       {{- end }}
     {{- if .Values.serviceAccount }}
-    serviceAccount: {{ .Values.serviceAccount }}
+    serviceAccountName: {{ .Values.serviceAccount }}
     {{- end }}
     spec:
       containers:


### PR DESCRIPTION
fix serviceaccount NAME specification in pod template

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
